### PR TITLE
Add support for the recommended auth method by Wistia when hitting their Data API

### DIFF
--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,16 +1,11 @@
-import base64
-
 import responses
 import pytest
 
 from wistia.client import WistiaClient
 
 
-def generate_http_basic_auth_string(username, password):
-    encoded_string = base64.b64encode(f"{username}:{password}".encode("utf-8")).decode(
-        "ascii"
-    )
-    return f"Basic {encoded_string}"
+def generate_http_bearer_auth_string(password):
+    return f"Bearer {password}"
 
 
 @pytest.fixture
@@ -29,7 +24,7 @@ def test_authentication_set_correctly_in_header(wistia_client):
     wistia_client.list_medias()
 
     # Then
-    expected_auth_header = generate_http_basic_auth_string("api", "letmein")
+    expected_auth_header = generate_http_bearer_auth_string("letmein")
     assert expected_auth_header == responses.calls[0].request.headers["Authorization"]
 
 

--- a/wistia/client.py
+++ b/wistia/client.py
@@ -11,18 +11,13 @@ log = logging.getLogger("wistiapy")
 class WistiaClient:
     API_BASE_URL = "https://api.wistia.com/v1/"
 
-    def __init__(self, user="api", api_password="", use_bearer=False):
+    def __init__(self, api_password=""):
         # https://wistia.com/support/developers/data-api#authentication
         self.session = requests.Session()
-        if use_bearer:
-            self.session.headers = {
-                "Authorization": f"Bearer ${api_password}",
-                **self.session.headers
-            }
-        else:
-            # this uses basic authentication which is not the recommended
-            # way to use the DATA API
-            self.session.auth = (user, api_password)
+        self.session.headers = {
+            "Authorization": f"Bearer {api_password}",
+            **self.session.headers
+        }
 
     def request(self, method, rel_path, **kwargs):
         url = f"{self.API_BASE_URL}{rel_path}"

--- a/wistia/client.py
+++ b/wistia/client.py
@@ -11,10 +11,18 @@ log = logging.getLogger("wistiapy")
 class WistiaClient:
     API_BASE_URL = "https://api.wistia.com/v1/"
 
-    def __init__(self, user="api", api_password=""):
+    def __init__(self, user="api", api_password="", use_bearer=False):
         # https://wistia.com/support/developers/data-api#authentication
         self.session = requests.Session()
-        self.session.auth = (user, api_password)
+        if use_bearer:
+            self.session.headers = {
+                "Authorization": f"Bearer ${api_password}",
+                **self.session.headers
+            }
+        else:
+            # this uses basic authentication which is not the recommended
+            # way to use the DATA API
+            self.session.auth = (user, api_password)
 
     def request(self, method, rel_path, **kwargs):
         url = f"{self.API_BASE_URL}{rel_path}"

--- a/wistia/dummy.py
+++ b/wistia/dummy.py
@@ -17,8 +17,8 @@ class FakeResponse(NamedTuple):
 
 
 class DummyWistiaClient(WistiaClient):
-    def __init__(self, user="api", api_password=""):
-        super().__init__(user, api_password)
+    def __init__(self, api_password=""):
+        super().__init__(api_password)
         self.session = (
             None
         )  # Make sure we don't hit the API in methods not yet overridden


### PR DESCRIPTION
We use this tool (thank you btw!)

We got an email from Wistia asking us to switch to the use of Bearer authorization so I added a way to use it without breaking existing uses of the WistiaClient class.

Details from Wistia: https://wistia.com/support/developers/wistia-deprecation-schedule#july-5th-authentication-in-query-parameters

Recommendation: https://wistia.com/support/developers/data-api#authentication

I'm not quite sure yet if this change will break Basic Authorization but I am raising it so that it would be easy to make the switch in case their changes break this.

I also added this change since it's the recommendation from them.

Let me know if you want me to add more detail to the PR

(I'll add a test/ tests, let me know if there's anything else)